### PR TITLE
Update selection states with item move with C-i/C-o

### DIFF
--- a/bin/sentaku
+++ b/bin/sentaku
@@ -1026,6 +1026,13 @@ _sf_item_move_up () { # {{{ Move the item up
   local v_replace=${_s_inputs[$replace]}
   _s_inputs[$_s_current_n]=$v_replace
   _s_inputs[$replace]=$v_current
+  ((_s_visual>=0)) && _s_visual=-2
+  if ((_s_visual!=-1)); then
+    local s_current=${_s_v_selected[$_s_current_n]}
+    local s_replace=${_s_v_selected[$replace]}
+    _s_v_selected[$_s_current_n]=$s_replace
+    _s_v_selected[$replace]=$s_current
+  fi
   [[ $_s_stdin -eq 0 ]] && _sf_align_values 0 0
   _sf_n_up
 } # }}}
@@ -1042,6 +1049,13 @@ _sf_item_move_down () { # {{{ Move the item down
   local v_replace=${_s_inputs[$replace]}
   _s_inputs[$_s_current_n]=$v_replace
   _s_inputs[$replace]=$v_current
+  ((_s_visual>=0)) && _s_visual=-2
+  if ((_s_visual!=-1)); then
+    local s_current=${_s_v_selected[$_s_current_n]}
+    local s_replace=${_s_v_selected[$replace]}
+    _s_v_selected[$_s_current_n]=$s_replace
+    _s_v_selected[$replace]=$s_current
+  fi
   [[ $_s_stdin -eq 0 ]] && _sf_align_values 0 0
   _sf_n_down
 } # }}}


### PR DESCRIPTION
たびたび失礼いたします。これは提案なのでございますが、複数選択をしている時の <kbd>C-i</kbd>/<kbd>C-o</kbd> による項目の移動において、選択状態も一緒に移動すると良いのではないかという様に考えるのです。

- また、この PR では <kbd>v</kbd> によって選択範囲を指定している途中 (`_s_visual>=0`) で <kbd>C-i</kbd>/<kbd>C-o</kbd> を押した時は、選択範囲の指定を其処で中断するというようにしました。
- ところでこの PR では `((_s_visual!=-1))` などのような算術式 (bash, zsh の両方で利用可能) を用いていますが、もし `[[ $_s_visual -ne -1 ]]` の様な形式を用いる理由があるようでしたら修正いたします。

お忙しいところすみませんが、ご検討いただければ幸いです。
